### PR TITLE
WIP: Add rclone package.py

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,27 @@
+# Instructions for how to contribute to this git repo
+
+This is a *work in progress* document.
+
+See [[SETUP.MD]] to run the spack commands. 
+
+Then exit the singularity container and change to the site-settings directory
+
+Some git commands examples:
+
+ - git checkout -B csc/PR/$NEWFEATURE # this creates a new branch called csc/pr/$NEWFEATURE. Replace $NEWFEATURE with something descriptive.
+ - git add csc-repo/packages/$NEWFEATURE/package.py # this adds the package.py for the new package
+ - git commit -v # write a commit message, -v shows which files you are committing [[https://chris.beams.io/posts/git-commit/]]
+
+Next is to fork the csc-spack-settings repo. Go to [[https://github.com/samiilvonen/csc-spack-settings]] and click "fork" and choose your private account.
+
+Next we need to add your fork as a remote to the git clone on your laptop:
+
+ - git remote add myfork git@github.com:$MYGITHUBUSERNAME/csc-spack-settings
+ - git fetch myfork
+ - git push myfork csc-repo/packages/$NEWFEATURE
+
+Next we go to github and click a green button with words like "create Pull Request". 
+
+The PR must go to the *csc/singularity* branch, not the master branch (which is the default branch as configured in github)
+
+Instructions for how to sync your fork with the main csc-spack-settings repo: TBA

--- a/csc-repo/packages/rclone/package.py
+++ b/csc-repo/packages/rclone/package.py
@@ -1,0 +1,74 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install rclone
+#
+# You can edit this file again by typing:
+#
+#     spack edit rclone
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+import os
+import glob
+import shutil
+
+
+class Rclone(Package):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    # If the-platinum-searcher in spack was working then one could perhaps use that..
+    homepage = "https://github.com/ncw/rclone/releases"
+    #url      = "https://codeload.github.com/ncw/rclone/tar.gz/v1.46.0"
+#dc6957687bf1092720aeff1cc67903135b24bff2b6af8bf9ef1717f31c2c2a9c  rclone-1.46.0.tar.gz
+    url = "https://github.com/ncw/rclone/releases/download/v1.46/rclone-v1.46.tar.gz"
+
+
+    # FIXME: Add proper versions and checksums here.
+    version('1.46', '3277e9aca1178707b12d7b7e63247ef3dd0c922d46d63b231f2d60d71e41ade2')
+
+    # FIXME: Add dependencies if required.
+    depends_on('go')
+
+    def install(self, spec, prefix):
+        # FIXME: Unknown build system
+        make()
+        
+#        try:
+#            os.makedirs(prefix)
+#        except OSError:
+#            pass
+
+	for path, dirs, files in os.walk(prefix):
+	  print path
+	  for f in files:
+	    print f
+	for path, dirs, files in os.walk('.'):
+	  print path
+	  for f in files:
+	    print f
+
+	shutil.copy('rclone', prefix)
+
+	# FIXME: how to add rclone to the path?
+#	spack_env.prepend_path('PATH', prefix)
+
+#        make('install')
+
+        env['GOPATH'] = self.stage.source_path + ':' + env['GOPATH']
+#	make()
+#        go('install', self.package, env=env)
+#        install_tree('bin', prefix.bin)


### PR DESCRIPTION
Still contains several FIXMEs. Currently it builds under gcc and created
a module show which looks like:

```
~: module load gcc
~: module show rclone
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   /appl/spack/run/modulefiles/linux-centos7-x86_64/gcc/8.2.0/rclone/1.46.lua:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
whatis("Name : rclone")
whatis("Version : 1.46")
whatis("Short description : FIXME: Put a proper description of your
package here.")
help([[FIXME: Put a proper description of your package here.]])
prepend_path("CMAKE_PREFIX_PATH","/appl/spack/run/gcc-8.2.0/rclone-1.46-qmmucd/")
prepend_path("GOPATH","/appl/spack/run/gcc-8.2.0/rclone-1.46-qmmucd")
setenv("RCLONE_ROOT","/appl/spack/run/gcc-8.2.0/rclone-1.46-qmmucd")
```
The executable is available in the $GOPATH directory:

```
~: $GOPATH/rclone --version
rclone v0.12.1-022-g4245ce31-csc/testing-beta
- os/arch: linux/amd64
- go version: go1.11.1
```